### PR TITLE
[WIP] Fix: Copy functionality failed to retrieve password when GnuPG key isn't already unlocked

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Anton Van Assche
+Copyright (c) 2023-2024 Anton Van Assche
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/bashpass-remote
+++ b/bashpass-remote
@@ -127,6 +127,7 @@ copy() {
     password=$(ssh -t "${user}@${host}" '$(command -v bashpass) --show' "${1}") || \
         error_out "failed to retrieve password '${1}' from remote" 1
     password=${password#*: }
+    [[ -z "${password}" ]] && error_out "failed to strip password '${1}' from remote response" 1
 
     if [[ "${1}" ]]; then
         if printf '%s' "${password}" | "${clipboard_command}"; then


### PR DESCRIPTION
## Description

Once done, this will resolve issue #1.

### Issues Resolved

Closes: #1

## Type of Change

-   [X] **Bug fix** (non-breaking change which fixes an issue)
-   [ ] **New feature** (non-breaking change which adds functionality)
-   [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
-   [ ] **Documentation update**

## Motivation and Context
When attempting to use the --copy option in BashPass-Remote, if the GnuPG key has not been unlocked on the server beforehand, the program will not prompt the user to enter the password like it does with the --list option. Instead, it will continuously attempt to decrypt the password file until it fails. Once it fails, the program will write an empty string or nothing at all, to the clipboard instead of the correct password.

<sup>By contributing, you agree that your contributions will be licensed under the [MIT License](https://github.com/AntonVanAssche/BashPass-Remote/blob/master/LICENSE.md), and follows the [contributing guidelines](https://github.com/AntonVanAssche/BashPass-Remote/blob/master/CONTRIBUTING.md).</sup>